### PR TITLE
Appdata related changes

### DIFF
--- a/data/com.github.alexkdeveloper.forgetpass.appdata.xml.in
+++ b/data/com.github.alexkdeveloper.forgetpass.appdata.xml.in
@@ -12,6 +12,9 @@
     <binary>com.github.alexkdeveloper.forgetpass</binary>
   </provides>
   <developer_name>Alex Kryuchkov</developer_name>
+  <developer id="io.github.alexkdeveloper">
+    <name>Alex Kryuchkov</name>
+  </developer>
   <url type="homepage">https://github.com/alexkdeveloper/forgetpass</url>
   <url type="bugtracker">https://github.com/alexkdeveloper/forgetpass/issues</url>
   <url type="help">https://github.com/alexkdeveloper/forgetpass/issues</url>

--- a/data/com.github.alexkdeveloper.forgetpass.appdata.xml.in
+++ b/data/com.github.alexkdeveloper.forgetpass.appdata.xml.in
@@ -27,21 +27,21 @@
   <launchable type="desktop-id">com.github.alexkdeveloper.forgetpass.desktop</launchable>
   <releases>
     <release version="1.0.17" date="2024-03-29">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
 	   <li>Updated Dutch translation</li>
 	</ul>
      </description>
     </release>
     <release version="1.0.16" date="2024-03-24">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
 	   <li>Updated to GNOME Platform version 46</li>
 	</ul>
      </description>
     </release>
      <release version="1.0.15" date="2024-01-10">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
 	   <li>Added Ukrainian translation</li>
            <li>Added Belarusian translation</li>
@@ -49,84 +49,84 @@
      </description>
     </release>
      <release version="1.0.14" date="2023-09-22">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
 	   <li>Updated to GNOME Platform version 45</li>
 	</ul>
      </description>
     </release>
      <release version="1.0.13" date="2023-03-22">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
 	   <li>Updated to GNOME Platform version 44</li>
 	</ul>
      </description>
     </release>
     <release version="1.0.12" date="2023-02-20">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
 	   <li>Minor UI update</li>
 	</ul>
      </description>
     </release>
     <release version="1.0.11" date="2023-01-24">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
            <li>Updated Italian translation</li>
 	</ul>
      </description>
     </release>
     <release version="1.0.10" date="2023-01-05">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
            <li>Port to AdwEntryRow</li>
 	</ul>
      </description>
     </release>
     <release version="1.0.9" date="2022-10-26">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
            <li>Added the ability to copy the password to the clipboard</li>
 	</ul>
      </description>
     </release>
     <release version="1.0.8" date="2022-10-03">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
            <li>The app icon has been updated</li>
 	</ul>
      </description>
     </release>
      <release version="1.0.7" date="2022-09-26">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
            <li>Added Spanish and Basque translations</li>
 	</ul>
      </description>
     </release>
      <release version="1.0.6" date="2022-09-24">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
            <li>Update to GNOME Platform version 43</li>
 	</ul>
      </description>
     </release>
     <release version="1.0.5" date="2022-06-28">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
            <li>Pop-up messages were introduced</li>
 	</ul>
      </description>
     </release>
     <release version="1.0.4" date="2022-06-20">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
            <li>Minor UI update</li>
 	</ul>
      </description>
     </release>
   <release version="1.0.3" date="2022-06-09">
-      <description translatable="no">
+      <description translate="no">
 	 <ul>
            <li>Added Italian translation</li>
 	   <li>Added Russian translation</li>
@@ -134,21 +134,21 @@
      </description>
     </release>
   <release version="1.0.2" date="2022-06-08">
-      <description translatable="no">
+      <description translate="no">
 	  <ul>
             <li>Libadwaita is included in the application</li>
 	  </ul>
      </description>
     </release>
    <release version="1.0.1" date="2022-05-17">
-      <description translatable="no">
+      <description translate="no">
 	<ul>
            <li>Added Dutch translation</li>
 	</ul>
      </description>
     </release>
     <release version="1.0.0" date="2022-04-29">
-      <description translatable="no">
+      <description translate="no">
        <ul>
           <li>Initial release</li>
        </ul>


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer